### PR TITLE
Hangfire Job starts multiple times - fix

### DIFF
--- a/Hangfire.MySql/JobQueue/MySqlFetchedJob.cs
+++ b/Hangfire.MySql/JobQueue/MySqlFetchedJob.cs
@@ -14,6 +14,9 @@ namespace Hangfire.MySql.JobQueue
         private readonly MySqlStorage _storage;
         private readonly IDbConnection _connection;
         private readonly int _id;
+        private bool _removedFromQueue;
+        private bool _requeued;
+        private bool _disposed;
 
         public MySqlFetchedJob(
             MySqlStorage storage, 
@@ -33,7 +36,17 @@ namespace Hangfire.MySql.JobQueue
 
         public void Dispose()
         {
+
+            if (_disposed) return;
+
+            if (!_removedFromQueue && !_requeued)
+            {
+                Requeue();
+            }
+
             _storage.ReleaseConnection(_connection);
+
+            _disposed = true;
         }
 
         public void RemoveFromQueue()
@@ -48,6 +61,8 @@ namespace Hangfire.MySql.JobQueue
                 {
                     id = _id
                 });
+
+            _removedFromQueue = true;
         }
 
         public void Requeue()
@@ -62,6 +77,7 @@ namespace Hangfire.MySql.JobQueue
                 {
                     id = _id
                 });
+            _requeued = true;
         }
 
         public string JobId { get; private set; }


### PR DESCRIPTION
On my instance of hangfire Jobs sometime start multiplle times (often at startup)
This is issue described at https://github.com/arnoldasgudas/Hangfire.MySqlStorage/issues/6
and at https://github.com/HangfireIO/Hangfire/issues/590

Changed queue implementation to utilize FetchToken (it was already in database in table) to ensure that same record will not be processed by multiple workes (job will be locked by update, and then loaded from db using fetch token)

