### PR TITLE
Update MySqlConnector to 1.0

### DIFF
--- a/Hangfire.MySql.Tests/CountersAggregatorTests.cs
+++ b/Hangfire.MySql.Tests/CountersAggregatorTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading;
 using Dapper;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Xunit;
 
 namespace Hangfire.MySql.Tests

--- a/Hangfire.MySql.Tests/ExpirationManagerTests.cs
+++ b/Hangfire.MySql.Tests/ExpirationManagerTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading;
 using Dapper;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Xunit;
 
 namespace Hangfire.MySql.Tests

--- a/Hangfire.MySql.Tests/JobQueue/MySqlJobQueueMonitoringApiTests.cs
+++ b/Hangfire.MySql.Tests/JobQueue/MySqlJobQueueMonitoringApiTests.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Transactions;
 using Dapper;
 using Hangfire.MySql.JobQueue;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Xunit;
 
 namespace Hangfire.MySql.Tests.JobQueue

--- a/Hangfire.MySql.Tests/JobQueue/MySqlJobQueueTests.cs
+++ b/Hangfire.MySql.Tests/JobQueue/MySqlJobQueueTests.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using Dapper;
 using Hangfire.MySql.JobQueue;
 using Moq;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Xunit;
 
 namespace Hangfire.MySql.Tests.JobQueue

--- a/Hangfire.MySql.Tests/Monitoring/MySqlMonitoringApiTests.cs
+++ b/Hangfire.MySql.Tests/Monitoring/MySqlMonitoringApiTests.cs
@@ -6,7 +6,7 @@ using Hangfire.MySql.JobQueue;
 using Hangfire.MySql.Monitoring;
 using Hangfire.Storage.Monitoring;
 using Moq;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Xunit;
 
 namespace Hangfire.MySql.Tests.Monitoring

--- a/Hangfire.MySql.Tests/MySqlStorageConnectionTests.cs
+++ b/Hangfire.MySql.Tests/MySqlStorageConnectionTests.cs
@@ -8,7 +8,7 @@ using Hangfire.MySql.JobQueue;
 using Hangfire.Server;
 using Hangfire.Storage;
 using Moq;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Xunit;
 
 namespace Hangfire.MySql.Tests

--- a/Hangfire.MySql.Tests/MySqlWriteOnlyTransactionTests.cs
+++ b/Hangfire.MySql.Tests/MySqlWriteOnlyTransactionTests.cs
@@ -6,7 +6,7 @@ using Dapper;
 using Hangfire.MySql.JobQueue;
 using Hangfire.States;
 using Moq;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Xunit;
 
 namespace Hangfire.MySql.Tests

--- a/Hangfire.MySql.Tests/Utils/ConnectionUtils.cs
+++ b/Hangfire.MySql.Tests/Utils/ConnectionUtils.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Hangfire.MySql.Tests
 {

--- a/Hangfire.MySql.Tests/Utils/TestDatabaseFixture.cs
+++ b/Hangfire.MySql.Tests/Utils/TestDatabaseFixture.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading;
 using Dapper;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Hangfire.MySql.Tests
 {

--- a/Hangfire.MySql/ExpirationManager.cs
+++ b/Hangfire.MySql/ExpirationManager.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using Dapper;
 using Hangfire.Logging;
 using Hangfire.Server;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Hangfire.MySql
 {

--- a/Hangfire.MySql/Hangfire.MySql.csproj
+++ b/Hangfire.MySql/Hangfire.MySql.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
-        <PackageReference Include="MySqlConnector" Version="0.47.1" />
+        <PackageReference Include="MySqlConnector" Version="1.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
         <PackageReference Include="Dapper" Version="1.50.5" />
         <PackageReference Include="Hangfire.Core" Version="1.6.21" />

--- a/Hangfire.MySql/JobQueue/MySqlJobQueue.cs
+++ b/Hangfire.MySql/JobQueue/MySqlJobQueue.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Data;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using Dapper;
-using Hangfire.Annotations;
 using Hangfire.Logging;
 using Hangfire.Storage;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Hangfire.MySql.JobQueue
 {

--- a/Hangfire.MySql/Monitoring/MySqlMonitoringApi.cs
+++ b/Hangfire.MySql/Monitoring/MySqlMonitoringApi.cs
@@ -10,7 +10,7 @@ using Hangfire.MySql.JobQueue;
 using Hangfire.States;
 using Hangfire.Storage;
 using Hangfire.Storage.Monitoring;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Hangfire.MySql.Monitoring
 {

--- a/Hangfire.MySql/MySqlObjectsInstaller.cs
+++ b/Hangfire.MySql/MySqlObjectsInstaller.cs
@@ -2,10 +2,9 @@
 using System.IO;
 using System.Reflection;
 using System.Text;
-using System.Transactions;
 using Dapper;
 using Hangfire.Logging;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Hangfire.MySql
 {

--- a/Hangfire.MySql/MySqlStorage.cs
+++ b/Hangfire.MySql/MySqlStorage.cs
@@ -10,7 +10,7 @@ using Hangfire.MySql.JobQueue;
 using Hangfire.MySql.Monitoring;
 using Hangfire.Server;
 using Hangfire.Storage;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using IsolationLevel = System.Transactions.IsolationLevel;
 
 namespace Hangfire.MySql

--- a/Hangfire.MySql/MySqlWriteOnlyTransaction.cs
+++ b/Hangfire.MySql/MySqlWriteOnlyTransaction.cs
@@ -6,7 +6,7 @@ using Hangfire.Common;
 using Hangfire.Logging;
 using Hangfire.States;
 using Hangfire.Storage;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Hangfire.MySql
 {


### PR DESCRIPTION
MySqlConnector 1.0 changes the primary namespace to `MySqlConnector`: mysql-net/MySqlConnector#824; this updates all relevant code.

This starts the discussion around updating MySqlConnector to 1.0, but doesn't need to be merged until it's out of beta.