### PR TITLE
Update Install.sql

### DIFF
--- a/Hangfire.MySql/Install.sql
+++ b/Hangfire.MySql/Install.sql
@@ -119,7 +119,7 @@ CREATE TABLE `[tablesPrefix]Server` (
 CREATE TABLE `[tablesPrefix]Set` (
   `Id` int(11) NOT NULL AUTO_INCREMENT,
   `Key` nvarchar(100) NOT NULL,
-  `Value` nvarchar(256) NOT NULL,
+  `Value` nvarchar(165) NOT NULL,
   `Score` float NOT NULL,
   `ExpireAt` datetime DEFAULT NULL,
   PRIMARY KEY (`Id`),


### PR DESCRIPTION
Specified key was too long; max key length is 767 bytes
With 10.1.47-MariaDB-0ubuntu0.18.04.1 - Ubuntu 18.04