### PR TITLE
primary key Id on table DistributedLock

### DIFF
--- a/Hangfire.MySql/Install.sql
+++ b/Hangfire.MySql/Install.sql
@@ -41,8 +41,10 @@ CREATE TABLE `[tablesPrefix]AggregatedCounter` (
 -- Table structure for `DistributedLock`
 -- ----------------------------
 CREATE TABLE `[tablesPrefix]DistributedLock` (
+   Id int(11) NOT NULL AUTO_INCREMENT,
   `Resource` nvarchar(100) NOT NULL,
-  `CreatedAt` datetime(6) NOT NULL
+  `CreatedAt` datetime(6) NOT NULL,
+   PRIMARY KEY (`Id`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;
 
 


### PR DESCRIPTION
some managed databases have alot of limitations to customize sql settings like 'sql_require_primary_key', so adding this ID removes this problem